### PR TITLE
Upgrade Armadillo, let Bazel manage Boost

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -61,17 +61,8 @@ cc_library(
         "src/svr_training",
     ],
     linkopts = select({
-        "@bazel_tools//src/conditions:windows": [
-            # Windows Link Opts
-            "-LIBPATH:C:\\\\boost\\\\stage\\\\lib",
-        ],
-        "@bazel_tools//src/conditions:darwin_x86_64": [
-            # Mac Link Opts
-        ],
         "//conditions:default": [
             # Linux Link Opts
-            "-lboost_system",
-            "-lboost_filesystem",
         ],
     }),
     visibility = ["//visibility:public"],
@@ -79,13 +70,11 @@ cc_library(
         "@bazel_tools//src/conditions:windows": [
             # Windows Dependencies
             "@pffft_lib_win//:pffft_win",
-            "@boost_headers_windows//:boost_header",
-        ],
-        "@bazel_tools//src/conditions:darwin_x86_64": [
-            # Mac Dependencies
         ],
         "//conditions:default": [
             # Linux Dependencies
+            "@boost//:system",
+            "@boost//:filesystem",
             "@pffft_lib_linux//:pffft_linux",
         ],
     }) + [

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -54,9 +54,9 @@ cc_library(
 # Armadillo Headers
 http_archive(
     name = "armadillo_headers",
-    strip_prefix = "armadillo-code-9.200.x",
-    urls = ["https://gitlab.com/conradsnicta/armadillo-code/-/archive/9.200.x/armadillo-code-9.200.x.zip"],
-    sha256 = "df078186a5bcc66e8621139451c751c8b54d4a899ae38470fcf0f37bfd6bb5f0",
+    strip_prefix = "armadillo-9.860.1",
+    urls = ["http://sourceforge.net/projects/arma/files/armadillo-9.860.1.tar.xz"],
+    sha256 = "1603888ab73b7f0588df1a37a464436eb0ff6b1372a9962ee1424b4329f165a9",
     build_file_content = """
 cc_library(
     name = "armadillo_header",
@@ -66,6 +66,7 @@ cc_library(
 )
 """,
 )
+
 
 ##################
 # Platform Linux #
@@ -121,3 +122,27 @@ cc_library(
 )
 """,
 )
+
+http_archive(
+    name = "bazel_skylib",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.0.2/bazel-skylib-1.0.2.tar.gz",
+        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.2/bazel-skylib-1.0.2.tar.gz",
+    ],
+    sha256 = "97e70364e9249702246c0e9444bccdc4b847bed1eb03c5a3ece4f83dfe6abc44",
+)
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+bazel_skylib_workspace()
+
+
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
+git_repository(
+    name = "com_github_nelhage_rules_boost",
+    commit = "9f9fb8b2f0213989247c9d5c0e814a8451d18d7f",
+    remote = "https://github.com/nelhage/rules_boost",
+    shallow_since = "1570056263 -0700",
+)
+
+load("@com_github_nelhage_rules_boost//:boost/boost.bzl", "boost_deps")
+boost_deps()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -54,9 +54,9 @@ cc_library(
 # Armadillo Headers
 http_archive(
     name = "armadillo_headers",
-    strip_prefix = "armadillo-9.860.1",
-    urls = ["http://sourceforge.net/projects/arma/files/armadillo-9.860.1.tar.xz"],
-    sha256 = "1603888ab73b7f0588df1a37a464436eb0ff6b1372a9962ee1424b4329f165a9",
+    strip_prefix = "armadillo-9.860.2",
+    urls = ["http://sourceforge.net/projects/arma/files/armadillo-9.860.2.tar.xz"],
+    sha256 = "d856ea58c18998997bcae6689784d2d3eeb5daf1379d569fddc277fe046a996b",
     build_file_content = """
 cc_library(
     name = "armadillo_header",

--- a/src/include/file_path.h
+++ b/src/include/file_path.h
@@ -20,7 +20,7 @@
 #include <fstream>
 #include <string>
 
-#include "boost/filesystem.hpp"
+#include <boost/filesystem.hpp>
 
 namespace Visqol {
 class FilePath {


### PR DESCRIPTION
The URL to download Armadillo was no longer valid, this pulls in `armadillo-9.860.1` which is the latest release as of today. Also, I couldn't get Bazel to pick up Boost on my system, so I've switched this to use `nelhage/rules_boost` which appears to work much better. I've tested this on both OS X and Linux, I haven't had a chance to see if it works on Windows as well.