### PR TITLE
Update pffft repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,8 @@ ViSQOL can be run from the command line, or integrated into a project and used t
 #### Linux Build Instructions
 1. ##### Install Bazel
 - Bazel can be install for Linux from [here](https://docs.bazel.build/versions/master/install-ubuntu.html).
-- Tested with Bazel version 0.22.0.
-2. ##### Install Boost
-- Boost can be installed on Linux with the following command: `sudo apt-get install libboost-all-dev`
-- Tested with Boost version 1.65.0.
-3. ##### Build ViSQOL
+- Tested with Bazel version `3.4.1`.
+2. ##### Build ViSQOL
 - Change directory to the root of the ViSQOL project (i.e. where the WORKSPACE file is) and run the following command: `bazel build :visqol -c opt`
 
 #### Windows Build Instructions (Experimental, last Tested on Windows 10 x64, 2020 August)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,6 +3,7 @@
 ########################
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
 
 # GoogleTest/GoogleMock framework.
 http_archive(
@@ -72,11 +73,10 @@ cc_library(
 # Platform Linux #
 ##################
 # PFFFT - Linux
-http_archive(
+new_git_repository(
     name = "pffft_lib_linux",
-    strip_prefix = "jpommier-pffft-29e4f76ac53b",
-    urls = ["https://bitbucket.org/jpommier/pffft/get/29e4f76ac53b.zip"],
-    sha256 = "bb10afba127904a0c6c553fa445082729b7d72373511bda1b12a5be0e03f318a",
+    remote = "https://bitbucket.org/jpommier/pffft.git",
+    branch = "master",
     build_file_content = """
 cc_library(
     name = "pffft_linux",
@@ -91,11 +91,10 @@ cc_library(
 # Platform Windows #
 ####################
 # PFFFT - Windows
-http_archive(
+new_git_repository(
     name = "pffft_lib_win",
-    strip_prefix = "jpommier-pffft-29e4f76ac53b",
-    urls = ["https://bitbucket.org/jpommier/pffft/get/29e4f76ac53b.zip"],
-    sha256 = "bb10afba127904a0c6c553fa445082729b7d72373511bda1b12a5be0e03f318a",
+    remote = "https://bitbucket.org/jpommier/pffft.git",
+    branch = "master",
     build_file_content = """
 cc_library(
     name = "pffft_win",


### PR DESCRIPTION
The old pffft repo is no longer available. I updated the repo location for linux to a mirror of the original pffft repo.

I also updated the linux build instructions.

Build completed successfully with the most recent bazel version. All unit tests passing.