### PR TITLE
Issue 31: Too few samples - fix patch running over end of file

### DIFF
--- a/src/comparison_patches_selector.cc
+++ b/src/comparison_patches_selector.cc
@@ -62,7 +62,7 @@ void ComparisonPatchesSelector::FindMostOptimalDegPatch(
       slide_offset = -1;
       continue;
     }
-    if (slide_offset >= spectrogram_data.NumCols()) {
+    if (slide_offset >= static_cast<int>(spectrogram_data.NumCols())) {
       // The start of the degraded is past the end of the spectrogram, so
       // nothing left to compare.
       break;
@@ -190,11 +190,10 @@ ComparisonPatchesSelector::FindMostOptimalDegPatches(
   // The for loop is used to find the offset which maximizes the similarity
   // score across all the patches.
   for (int slide_offset = lower_limit;
-       slide_offset <= ref_patch_indices[last_index] + search_window;
+       slide_offset <= static_cast<int>(ref_patch_indices[last_index] + search_window);
        slide_offset++) {
-    if (slide_offset >= num_frames_in_deg_spectro) {
-      // The frame offset for degraded start patch cannot be more than the
-      // number of frames in the degraded spectrogram.
+    if (slide_offset >= (static_cast<int>(num_frames_in_deg_spectro-num_frames_per_patch))) {
+      // This prevents the final degraded patch from running over the end of the audio file.
       break;
     }
     if (cumulative_similarity_dp[last_index][slide_offset] >


### PR DESCRIPTION
The failure was occurring because the final patch was running over the end of the degraded file e.g. the degraded file was 7s long but the final patch was selected to be from 6.9s -> 7.3s. So I added a check to ensure that the final patch cannot run over the end of the file.

I also added some `static_cast<int>` to get rid of a few compiler warnings.