### PR TITLE
visqol: add degraded energy feature output

### DIFF
--- a/src/amatrix.cc
+++ b/src/amatrix.cc
@@ -14,13 +14,13 @@
 
 #include "amatrix.h"
 
+#include <armadillo>
 #include <complex>
 #include <utility>
 #include <valarray>
 #include <vector>
 
 #include "absl/types/span.h"
-#include <armadillo>
 
 namespace Visqol {
 template <typename T>
@@ -331,6 +331,13 @@ inline AMatrix<T> AMatrix<T>::FlipUpDown() const {
 template <typename T>
 inline AMatrix<T> AMatrix<T>::Mean(kDimension dim) const {
   return AMatrix<T>(arma::mean(matrix_, static_cast<int>(dim)));
+}
+
+template <typename T>
+inline AMatrix<double> AMatrix<T>::StdDev(kDimension dim) const {
+  // The second parameter of arma::stddev is norm_type.
+  // norm_type=0 means that stddev should use the unbiased estimate.
+  return AMatrix<double>(arma::stddev(matrix_, 0, static_cast<int>(dim)));
 }
 
 template <typename T>

--- a/src/include/amatrix.h
+++ b/src/include/amatrix.h
@@ -94,6 +94,7 @@ class AMatrix {
   AMatrix<T> JoinVertically(const AMatrix<T> &other) const;
   AMatrix<T> FlipUpDown() const;
   AMatrix<T> Mean(kDimension dim) const;
+  AMatrix<double> StdDev(kDimension dim) const;
 
   size_t NumRows() const;
   size_t NumCols() const;

--- a/src/include/patch_similarity_comparator.h
+++ b/src/include/patch_similarity_comparator.h
@@ -37,6 +37,18 @@ struct PatchSimilarityResult {
   AMatrix<double> freq_band_means;
 
   /**
+   * A 1-D matrix with the variance over time of each frequency.
+   */
+  AMatrix<double> freq_band_stddevs;
+
+  /**
+   * A 1-D matrix with the average energy over time of each frequency.
+   *
+   * The energy here is only for the degraded signal.
+   */
+  AMatrix<double> freq_band_deg_energy;
+
+  /**
    * The similarity score following a comparison between a single reference
    * patch and a single degraded patch.
    */

--- a/src/include/sim_results_writer.h
+++ b/src/include/sim_results_writer.h
@@ -201,7 +201,9 @@ class SimilarityResultsWriter {
   static void WriteResultsToCSV(const FilePath &csv_res_path,
                                 const SimilarityResultMsg &sim_res_msg,
                                 const bool output_moslqo = true,
-                                const bool output_fvnsim = true) {
+                                const bool output_fvnsim = true,
+                                const bool output_stddev = true,
+                                const bool output_fvdegenergy = true) {
     // If this file does not already exist, we need to write the header.
     const bool write_header = !csv_res_path.Exists();
     std::ofstream out_file;
@@ -218,6 +220,16 @@ class SimilarityResultsWriter {
           out_file << ",fvnsim" << i;
         }
       }
+      if (output_stddev) {
+        for (size_t i = 0; i < sim_res_msg.fstdnsim_size(); i++) {
+          out_file << ",fstdnsim" << i;
+        }
+      }
+      if (output_fvdegenergy) {
+        for (size_t i = 0; i < sim_res_msg.fvdegenergy_size(); i++) {
+          out_file << ",fvdegenergy" << i;
+        }
+      }
       out_file << std::endl;
     }
 
@@ -231,6 +243,16 @@ class SimilarityResultsWriter {
     if (output_fvnsim) {
       for (size_t i = 0; i < sim_res_msg.fvnsim_size(); i++) {
         out_file << "," << std::setprecision(9) << sim_res_msg.fvnsim(i);
+      }
+    }
+    if (output_stddev) {
+      for (size_t i = 0; i < sim_res_msg.fstdnsim_size(); i++) {
+        out_file << "," << std::setprecision(9) << sim_res_msg.fstdnsim(i);
+      }
+    }
+    if (output_fvdegenergy) {
+      for (size_t i = 0; i < sim_res_msg.fvdegenergy_size(); i++) {
+        out_file << "," << std::setprecision(9) << sim_res_msg.fvdegenergy(i);
       }
     }
 

--- a/src/include/similarity_result.h
+++ b/src/include/similarity_result.h
@@ -60,6 +60,16 @@ struct SimilarityResult {
   std::vector<double> fvnsim;
 
   /**
+   * Standard deviation in similarity for each frequency.
+   */
+  std::vector<double> fstdnsim;
+
+  /**
+   * Degraded energy for each frequency.
+   */
+  std::vector<double> fvdegenergy;
+
+  /**
    * Stores the center frequency bands that the above FVNSIM scores correspond
    * to. Values are stored running from the lowest frequency band to the
    * highest.

--- a/src/include/visqol.h
+++ b/src/include/visqol.h
@@ -85,7 +85,7 @@ class Visqol {
                     const SimilarityToQualityMapper *mapper) const;
 
   /**
-   * Prodcues a set of FVNSIM scores, which represent the similarity between
+   * Produces a set of FVNSIM scores, which represent the similarity between
    * the two signals for each frequency band. This is done by calculating the
    * mean similarity score for each frequency band across all compared patches.
    *
@@ -94,6 +94,30 @@ class Visqol {
    * @return The resulting set of FVNSIM scores.
    */
   AMatrix<double> CalcPerPatchMeanFreqBandMeans(
+      const std::vector<PatchSimilarityResult> &sim_match_info) const;
+
+  /**
+   * Produces a set of FVNSIM scores' stddev in similarity between
+   * the two signals for each frequency band. This is done by calculating the
+   * mean similarity score for each frequency band across all compared patches.
+   *
+   * @param sim_match_info The similarity scores for each patch comparison.
+   * @param frame_duration The frame duration in seconds.
+   *
+   * @return The resulting set of FSTDNSIM scores.
+   */
+  AMatrix<double> CalcPerPatchMeanFreqBandStdDevs(
+      const std::vector<PatchSimilarityResult> &sim_match_info,
+      const double frame_duration) const;
+
+  /**
+   * Produces a set of per frequency energies in the degraded signal.
+   *
+   * @param sim_match_info The similarity scores for each patch comparison.
+   *
+   * @return The resulting set of per frequency energies.
+   */
+  AMatrix<double> CalcPerPatchMeanFreqBandDegradedEnergy(
       const std::vector<PatchSimilarityResult> &sim_match_info) const;
 
   /**

--- a/src/neurogram_similiarity_index_measure.cc
+++ b/src/neurogram_similiarity_index_measure.cc
@@ -68,7 +68,11 @@ PatchSimilarityResult NeurogramSimiliarityIndexMeasure::MeasurePatchSimilarity(
   auto structure = structure_numer.PointWiseDivide(structure_denom);
   auto sim_map = intensity.PointWiseProduct(structure);
 
-  auto freq_band_means = sim_map.Mean(kDimension::ROW);  // A.K.A. FVNSIM
+  // These three matrices correspond to the similarity_result.proto fields
+  // such as fvnsim.
+  auto freq_band_deg_energy = deg_patch.Mean(kDimension::ROW);
+  auto freq_band_means = sim_map.Mean(kDimension::ROW);
+  auto freq_band_stddevs = sim_map.StdDev(kDimension::ROW);
 
   double freq_band_sim_sum = 0;
   std::for_each(freq_band_means.begin(), freq_band_means.end(),
@@ -78,7 +82,9 @@ PatchSimilarityResult NeurogramSimiliarityIndexMeasure::MeasurePatchSimilarity(
 
   PatchSimilarityResult r;
   r.similarity = mean_freq_band_means;
+  r.freq_band_deg_energy = std::move(freq_band_deg_energy);
   r.freq_band_means = std::move(freq_band_means);
+  r.freq_band_stddevs = std::move(freq_band_stddevs);
   return r;
 }
 }  // namespace Visqol

--- a/src/proto/similarity_result.proto
+++ b/src/proto/similarity_result.proto
@@ -17,7 +17,6 @@ syntax = "proto3";
 package Visqol;
 
 message SimilarityResultMsg {
-
   // Contains info related to the similarity result for each patch.
   message PatchSimilarityMsg {
     // Similarity score for this patch.
@@ -48,8 +47,16 @@ message SimilarityResultMsg {
   double vnsim = 2;
 
   // Mean of per patch mean frequency band similarity across all patches.
-  // Lowest to highest frequency bands:
+  // The order of the elements is lowest to highest in frequency bands.
   repeated double fvnsim = 3;
+
+  // Stddev of per patch mean frequency band similarity across all patches.
+  // The order of the elements is lowest to highest in frequency bands.
+  repeated double fstdnsim = 8;
+
+  // Mean/Average energy over patches for each frequency band in the degraded
+  // signal.
+  repeated double fvdegenergy = 9;
 
   // Lowest to highest center frequency bands:
   repeated double center_freq_bands = 4;

--- a/src/visqol_manager.cc
+++ b/src/visqol_manager.cc
@@ -176,18 +176,25 @@ SimilarityResultMsg VisqolManager::PopulateSimResultMsg(
   sim_result_msg.set_moslqo(sim_result.moslqo);
   sim_result_msg.set_vnsim(sim_result.vnsim);
 
-  auto fvnsim = sim_result.fvnsim;
-  for (auto itr = fvnsim.begin(); itr != fvnsim.end(); ++itr) {
-    sim_result_msg.add_fvnsim(*itr);
+  for (double val : sim_result.fvnsim) {
+    sim_result_msg.add_fvnsim(val);
   }
 
-  auto cfb = sim_result.center_freq_bands;
-  for (auto itr = cfb.begin(); itr != cfb.end(); ++itr) {
-    sim_result_msg.add_center_freq_bands(*itr);
+  for (double val : sim_result.fstdnsim) {
+    sim_result_msg.add_fstdnsim(val);
   }
 
-  for (const auto& patch : sim_result.debug_info.patch_sims) {
-    auto patch_msg = sim_result_msg.add_patch_sims();
+  for (double val : sim_result.center_freq_bands) {
+    sim_result_msg.add_center_freq_bands(val);
+  }
+
+  for (double val : sim_result.fvdegenergy) {
+    sim_result_msg.add_fvdegenergy(val);
+  }
+
+  for (const PatchSimilarityResult& patch : sim_result.debug_info.patch_sims) {
+    SimilarityResultMsg_PatchSimilarityMsg* patch_msg =
+        sim_result_msg.add_patch_sims();
     patch_msg->set_similarity(patch.similarity);
     patch_msg->set_ref_patch_start_time(patch.ref_patch_start_time);
     patch_msg->set_ref_patch_end_time(patch.ref_patch_end_time);


### PR DESCRIPTION

The degraded energy allows to track features that are non-relative, for example, narrowband.

PiperOrigin-RevId: 355192239