### PR TITLE
Fix linear growth in memory during batch operations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /bazel-out
 /bazel-testlogs
 /bazel-visqol
+.vscode

--- a/scripts/profile_memory_batch.sh
+++ b/scripts/profile_memory_batch.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+echo "reference,degraded" > ./tmp_batch.csv
+echo "./testdata/conformance_testdata_subset/guitar48_stereo.wav,./testdata/conformance_testdata_subset/guitar48_stereo_64kbps_aac.wav" >> ./tmp_batch.csv
+echo "./testdata/conformance_testdata_subset/contrabassoon48_stereo.wav,./testdata/conformance_testdata_subset/contrabassoon48_stereo_24kbps_aac.wav" >> ./tmp_batch.csv
+echo "./testdata/conformance_testdata_subset/glock48_stereo.wav,./testdata/conformance_testdata_subset/glock48_stereo_48kbps_aac.wav" >> ./tmp_batch.csv
+echo "./testdata/conformance_testdata_subset/harpsichord48_stereo.wav,./testdata/conformance_testdata_subset/harpsichord48_stereo_96kbps_mp3.wav" >> ./tmp_batch.csv
+echo "./testdata/conformance_testdata_subset/moonlight48_stereo.wav,./testdata/conformance_testdata_subset/moonlight48_stereo_128kbps_aac.wav" >> ./tmp_batch.csv
+
+valgrind --tool=massif -v ./bazel-bin/visqol --batch_input_csv "./tmp_batch.csv" --results_csv "./tmp_results.csv" --output_debug "./tmp_debug.csv"
+
+for f in ./massif.out.*; do
+    ms_print $f > ./"mem-profile.txt"
+done
+
+rm ./massif.out.*
+rm ./tmp_*.csv

--- a/scripts/profile_memory_single.sh
+++ b/scripts/profile_memory_single.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+valgrind --tool=massif -v ./bazel-bin/visqol --reference_file ./testdata/conformance_testdata_subset/guitar48_stereo.wav --degraded_file ./testdata/conformance_testdata_subset/guitar48_stereo_64kbps_aac.wav
+
+for f in ./massif.out.*; do
+    ms_print $f > ./"mem-profile.txt"
+done
+
+rm ./massif.out.*

--- a/src/include/visqol_manager.h
+++ b/src/include/visqol_manager.h
@@ -98,22 +98,6 @@ class VisqolManager {
                     const int search_window );
 
   /**
-   * Perform comparisons on a number of reference/degraded audio file pairs.
-   *
-   * If any of the comparisons fail, an error will be logged and the next
-   * comparison will be moved onto. Only comparisons that do not fail will have
-   * their results returned in the result vector.
-   *
-   * @param signals_to_compare A vector of reference/degraded signal pairs to
-   *    be compared to each other.
-   *
-   * @return A Vector of SimilarityResultMsgs for the comparisons that completed
-   *    successfully.
-   */
-  std::vector<SimilarityResultMsg> Run(
-      const std::vector<ReferenceDegradedPathPair>& signals_to_compare);
-
-  /**
    * Perform a comparison on a single reference/degraded audio file pair.
    *
    * @param ref_signal_path The path to the reference audio file.

--- a/src/visqol_manager.cc
+++ b/src/visqol_manager.cc
@@ -104,29 +104,6 @@ absl::Status VisqolManager::InitSimilarityToQualityMapper(
   return sim_to_qual_->Init();
 }
 
-std::vector<SimilarityResultMsg> VisqolManager::Run(
-    const std::vector<ReferenceDegradedPathPair>& signals_to_compare) {
-  std::vector<SimilarityResultMsg> sim_results;
-  // Iterate over all signal pairs to compare.
-  for (const auto& signal_pair : signals_to_compare) {
-    // Run comparison on a single signal pair.
-    auto status_or = Run(signal_pair.reference, signal_pair.degraded);
-    // If successful save value, else log an error.
-    if (status_or.ok()) {
-      sim_results.push_back(status_or.value());
-    } else {
-      ABSL_RAW_LOG(ERROR, "Error executing ViSQOL: %s.",
-                   status_or.status().ToString().c_str());
-      // A status of aborted gets thrown when visqol hasn't been init'd.
-      // So if that happens we want to quit processing.
-      if (status_or.status().code() == absl::StatusCode::kAborted) {
-        break;
-      }
-    }
-  }
-  return sim_results;
-}
-
 absl::StatusOr<SimilarityResultMsg> VisqolManager::Run(
     const FilePath& ref_signal_path, const FilePath& deg_signal_path) {
   // Ensure the initialization succeeded.

--- a/tests/visqol_manager_test.cc
+++ b/tests/visqol_manager_test.cc
@@ -210,34 +210,6 @@ TEST(VisqolCommandLineTest, IdenticalStddevNsim) {
 }
 
 /**
- * Ensure that multiple input pairs can be processed successfully.
- */
-TEST(VisqolCommandLineTest, MultipleInputPairs) {
-  Visqol::VisqolManager visqol;
-  auto status =
-      visqol.Init(FilePath::currentWorkingDir() + kDefaultAudioModelFile,
-                  false, false, 60);
-  ASSERT_TRUE(status.ok());
-
-  std::vector<ReferenceDegradedPathPair> path_pairs;
-  path_pairs.push_back(ReferenceDegradedPathPair{
-      FilePath("testdata/clean_speech/CA01_01.wav"),
-      FilePath("testdata/clean_speech/transcoded_CA01_01.wav")});
-  path_pairs.push_back(ReferenceDegradedPathPair{
-      FilePath(
-          "testdata/conformance_testdata_subset/guitar48_stereo.wav"),
-      FilePath(
-          "testdata/conformance_testdata_subset/guitar48_stereo_64kbps_aac.wav")
-          });
-
-  auto result_vec = visqol.Run(path_pairs);
-
-  ASSERT_EQ(kCountOfMultiplePairResults, result_vec.size());
-  EXPECT_NEAR(kMonoKnownMos, result_vec[0].moslqo(), kTolerance);
-  EXPECT_NEAR(kConformanceGuitar64aac, result_vec[1].moslqo(), kTolerance);
-}
-
-/**
  * Ensure that ViSQOL will complete successfully for input audio signals with
  * non-48k sample rates.
  */


### PR DESCRIPTION
Hi @mchinen ,

I took a look at the issue of linear growth in memory during batch mode.

The root cause was waiting until all signal pairs had been processed before printing the results. Because the results are relatively large this actually had quite an impact. So I simply changed it to write out the results after each comparison.

I graphed the memory consumption over the life of the program for a batch of 50 files before and after this fix and you can see the memory is now constant:

![batch-mem-consumption](https://user-images.githubusercontent.com/7213585/120099593-40874880-c134-11eb-9f42-88eac77a7fd0.png)

In terms of implementation, I moved the `for-each`, where we iterate over each signal pair in the batch, from the `visqol` class up to the `main` function. I considered the opposite - moving the writing of results out of `main` and into `visqol` - but I think it doesn't make as much sense for the `visqol` class to be aware of any result-writing logic.

I also added a couple of scripts that I have found useful for profiling `visqol` memory using `valgrind massif`.

Let me know what you think!
Feargus