### PR TITLE
Make ViSQOL pip installable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 /bazel-out
 /bazel-testlogs
 /bazel-visqol
+/visqol_lib_py
 .vscode

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,12 @@
+import os
+from setuptools import setup
+
+os.system("./setup.sh")
+
+setup(
+    name="visqol_lib_py",
+    version="3.3.3",
+    url="https://github.com/google/visqol",
+    description="An objective, full-reference metric for perceived audio quality.",
+    package_dir={"": "visqol_lib_py"},
+)

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,12 @@
+VISQOL_LIB_PY_DIR=visqol_lib_py
+
+bazel build -c opt //:similarity_result_py_pb2
+bazel build -c opt //:visqol_config_py_pb2
+bazel build -c opt //python:visqol_lib_py.so
+
+mkdir -rf $VISQOL_LIB_PY_DIR
+mkdir $VISQOL_LIB_PY_DIR
+
+mv bazel-bin/*_pb2.py $VISQOL_LIB_PY_DIR
+mv bazel-bin/python/visqol_lib_py.so $VISQOL_LIB_PY_DIR
+mv bazel-bin/python/visqol_lib_py.so.runfiles/__main__/model/* $VISQOL_LIB_PY_DIR


### PR DESCRIPTION
Still uses bazel to build the protobuf python files and pybind11 dynamic library, since it is the easiest way I was able to deal with all the necessary dependencies and keep everything in sync. But please let me know if there is a cleaner way.