### PR TITLE
Copy instead of moving when installing

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -7,6 +7,7 @@ bazel build -c opt //python:visqol_lib_py.so
 mkdir -rf $VISQOL_LIB_PY_DIR
 mkdir $VISQOL_LIB_PY_DIR
 
-mv bazel-bin/*_pb2.py $VISQOL_LIB_PY_DIR
-mv bazel-bin/python/visqol_lib_py.so $VISQOL_LIB_PY_DIR
-mv bazel-bin/python/visqol_lib_py.so.runfiles/__main__/model/* $VISQOL_LIB_PY_DIR
+cp bazel-bin/*_pb2.py $VISQOL_LIB_PY_DIR
+cp bazel-bin/python/visqol_lib_py.so $VISQOL_LIB_PY_DIR
+cp model/lattice_tcditugenmeetpackhref_ls2_nl60_lr12_bs2048_learn.005_ep2400_train1_7_raw.tflite $VISQOL_LIB_PY_DIR
+cp model/libsvm_nu_svr_model.txt $VISQOL_LIB_PY_DIR


### PR DESCRIPTION
This also makes sure that the model files aren't symlinks, making it more robust.