### PR TITLE
Gammatone optimization using Eigen matrix operations

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -129,7 +129,7 @@ cc_library(
         ":similarity_to_quality_mapper",
         ":tflite_quality_mapper",
         ":visqol_config_cc_proto",
-        "@armadillo_headers//:armadillo_header",
+        "@eigen//:eigen",
         "@com_google_absl//absl/flags:flag",
         "@com_google_absl//absl/flags:parse",
         "@com_google_absl//absl/flags:usage",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -158,20 +158,21 @@ cc_library(
     urls = ["https://github.com/cjlin1/libsvm/archive/v324.zip"],
 )
 
-# Armadillo Headers
+# Eigen dependency
 http_archive(
-    name = "armadillo_headers",
+    name = "eigen",
     build_file_content = """
 cc_library(
-    name = "armadillo_header",
-    hdrs = glob(["include/armadillo", "include/armadillo_bits/*.hpp"]),
-    includes = ["include/"],
-    visibility = ["//visibility:public"],
+    name = 'eigen',
+    srcs = [],
+    includes = ['Eigen'],
+    hdrs = glob(['Eigen/**']),
+    visibility = ['//visibility:public'],
 )
 """,
-    sha256 = "53d7ad6124d06fdede8d839c091c649c794dae204666f1be0d30d7931737d635",
-    strip_prefix = "armadillo-9.900.1",
-    urls = ["http://sourceforge.net/projects/arma/files/armadillo-9.900.1.tar.xz"],
+    sha256 = "0fa5cafe78f66d2b501b43016858070d52ba47bd9b1016b0165a7b8e04675677",
+    strip_prefix = "eigen-3.3.9",
+    urls = ["https://gitlab.com/libeigen/eigen/-/archive/3.3.9/eigen-3.3.9.tar.bz2",],
 )
 
 # PFFFT

--- a/src/include/amatrix.h
+++ b/src/include/amatrix.h
@@ -17,13 +17,12 @@
 #ifndef VISQOL_INCLUDE_AMATRIX_H
 #define VISQOL_INCLUDE_AMATRIX_H
 
-#include <armadillo>
+#include "Eigen/Dense"
 #include <memory>
 #include <valarray>
 #include <vector>
 
 #include "absl/types/span.h"
-#define ARMA_64BIT_WORD
 
 #if defined(_MSC_VER) && _MSC_VER >= 1400
 #pragma warning(push)
@@ -32,6 +31,10 @@
 
 namespace Visqol {
 enum class kDimension { COLUMN = 0, ROW = 1 };
+
+// Define an alias for the Eigen matrix
+template<class T>
+using BackendMatrix = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>;
 
 template <typename T>
 class AMatrix;
@@ -43,7 +46,7 @@ template <typename T>
 class AMatrix {
  public:
   AMatrix<T>() {}
-  AMatrix<T>(const arma::Mat<T>& mat);
+  AMatrix<T>(const BackendMatrix<T>& mat);
   AMatrix<T>(const AMatrix<T>& other);
   AMatrix<T>(const std::vector<T>& col);
   AMatrix<T>(const absl::Span<T>& col);
@@ -52,7 +55,7 @@ class AMatrix {
   AMatrix<T>(size_t rows, size_t cols);
   AMatrix<T>(size_t rows, size_t cols, std::vector<T>&& data);
   AMatrix<T>(size_t rows, size_t cols, const std::vector<T>& data);
-  AMatrix<T>(arma::Mat<T>&& matrix);  // could this be private?
+  AMatrix<T>(BackendMatrix<T>&& matrix);  // could this be private?
   T& operator()(size_t row, size_t column);
   T operator()(size_t row, size_t column) const;
   T& operator()(size_t elementIndex);
@@ -104,11 +107,11 @@ class AMatrix {
   std::valarray<T> ToValArray() const;
 
   // hack to access private member
-  const arma::Mat<T>& GetArmaMat() const;
+  const BackendMatrix<T>& GetBackendMat() const;
 
  public:
-  typedef typename arma::Mat<T>::iterator iterator;
-  typedef typename arma::Mat<T>::const_iterator const_iterator;
+  using iterator = T*;
+  using const_iterator = const T*;
   iterator begin();
   iterator end();
   const_iterator cbegin() const;
@@ -118,7 +121,7 @@ class AMatrix {
   T* mutData() const;  // bit of a hack
 
  private:
-  arma::Mat<T> matrix_;
+  BackendMatrix<T> matrix_;
 };
 }  // namespace Visqol
 

--- a/src/include/equivalent_rectangular_bandwidth.h
+++ b/src/include/equivalent_rectangular_bandwidth.h
@@ -28,6 +28,23 @@ namespace Visqol {
  */
 struct ErbFiltersResult {
   /**
+  * An enumeration that assigns the ERB filters coefficient names to the corresponding
+  * column indices of the ErbFiltersResult::filterCoeffs matrix.
+  */
+  enum CoeffsMap {
+    A0 = 0,
+    A11 = 1,
+    A12 = 2,
+    A13 = 3,
+    A14 = 4,
+    A2 = 5,
+    B0 = 6,
+    B1 = 7,
+    B2 = 8,
+    Gain = 9
+  };
+
+  /**
    * The filter coefficients for the ERB filter.
    */
   std::vector<std::vector<double>> filterCoeffs;

--- a/src/include/gammatone_filterbank.h
+++ b/src/include/gammatone_filterbank.h
@@ -22,6 +22,8 @@
 
 #include "amatrix.h"
 
+#include "Eigen/Dense"
+
 namespace Visqol {
 
 /**
@@ -66,7 +68,7 @@ class GammatoneFilterBank {
    *
    * @return The filtered output.
    */
-  AMatrix<double> ApplyFilter(const std::valarray<double>& signal);
+  Eigen::MatrixXd ApplyFilter(const Eigen::MatrixXd &signal);
 
   /**
    * Set the equivalent rectangular bandwidth filter coefficients that are to
@@ -95,20 +97,21 @@ class GammatoneFilterBank {
    */
   double min_freq_;
 
-  std::valarray<std::valarray<double>> fltr_cond_1_;
-  std::valarray<std::valarray<double>> fltr_cond_2_;
-  std::valarray<std::valarray<double>> fltr_cond_3_;
-  std::valarray<std::valarray<double>> fltr_cond_4_;
-  std::valarray<double> fltr_coeff_A0_;
-  std::valarray<double> fltr_coeff_A11_;
-  std::valarray<double> fltr_coeff_A12_;
-  std::valarray<double> fltr_coeff_A13_;
-  std::valarray<double> fltr_coeff_A14_;
-  std::valarray<double> fltr_coeff_A2_;
-  std::valarray<double> fltr_coeff_B0_;
-  std::valarray<double> fltr_coeff_B1_;
-  std::valarray<double> fltr_coeff_B2_;
-  std::valarray<double> fltr_coeff_gain_;
+  Eigen::MatrixXd fltr_cond_1_;
+  Eigen::MatrixXd fltr_cond_2_;
+  Eigen::MatrixXd fltr_cond_3_;
+  Eigen::MatrixXd fltr_cond_4_;
+  Eigen::MatrixXd a1;
+  Eigen::MatrixXd a2;
+  Eigen::MatrixXd a3;
+  Eigen::MatrixXd a4;
+  Eigen::MatrixXd b;
+
+  /**
+   * This is dependent to the filters order. For a 2nd order filter
+   * we need 3 coeffs for numerator and denominator.
+   */
+   const int kFilterLength = 3;
 };
 }  // namespace Visqol
 

--- a/tests/gammatone_filterbank_test.cc
+++ b/tests/gammatone_filterbank_test.cc
@@ -25,13 +25,13 @@ const size_t kSampleRate = 48000;
 const size_t kNumBands = 32;
 const double kMinFreq = 50;
 
-// The contents of this input signal are random figures.
-const AMatrix<double> k10Samples{
-    std::valarray<double>{0.2, 0.4, 0.6, 0.8, 0.9, 0.1, 0.3, 0.5, 0.7, 0.9}};
-
 // Ensure that the output matrix from the signal filter has the correct
 // dimensions.
 TEST(ApplyFilterTest, basic_positive_flow) {
+  // The contents of this input signal are random figures.
+  Eigen::MatrixXd k10Samples (10, 1);
+  k10Samples << 0.2, 0.4, 0.6, 0.8, 0.9, 0.1, 0.3, 0.5, 0.7, 0.9;
+
   auto filter_bank = GammatoneFilterBank{kNumBands, kMinFreq};
   auto erb = EquivalentRectangularBandwidth::MakeFilters(
       kSampleRate, kNumBands, kMinFreq, kSampleRate / 2);
@@ -39,10 +39,10 @@ TEST(ApplyFilterTest, basic_positive_flow) {
   filter_coeffs = filter_coeffs.FlipUpDown();
   filter_bank.SetFilterCoefficients(filter_coeffs);
   auto filtered_signal =
-      filter_bank.ApplyFilter(k10Samples.GetColumn(0).ToValArray());
+      filter_bank.ApplyFilter(k10Samples);
 
-  ASSERT_EQ(k10Samples.NumElements(), filtered_signal.NumCols());
-  ASSERT_EQ(kNumBands, filtered_signal.NumRows());
+  ASSERT_EQ(k10Samples.size(), filtered_signal.cols());
+  ASSERT_EQ(kNumBands, filtered_signal.rows());
 }
 
 }  // namespace


### PR DESCRIPTION
Hi everyone, I am opening this PR to propose some gammatone filterbank optimizations using matrix operations with the Eigen library.

The proposed changes have two parts:
* replacing current linear algebra backend library (Armadillo) with Eigen,
* using Eigen operations for a faster gammatone filterbank implementation.

The proposed changes show bigger runtime improvements for shorter input files, and from our measurements we can see approx. 1.5x faster runtime for a 15" input, up to 2x for a 3" input file.

If we also combine this improvement with `--search_window_radius 0` and `--disable_realignment` (when reference and degraded have no inter-frame lag), we could get approx. 5x faster runtimes for a 15" input.

The changes in this PR are a bit lengthy so I am also opening PR with only the first part that replaces Armadillo with Eigen to keep it more contained and make the review process a bit easier. I also opened https://github.com/terpste/visqol/pull/6 only for comparison purposes, to highlight only the gammatone filterbank additions.