### PR TITLE
Replace Armadillo with Eigen

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -129,7 +129,7 @@ cc_library(
         ":similarity_to_quality_mapper",
         ":tflite_quality_mapper",
         ":visqol_config_cc_proto",
-        "@armadillo_headers//:armadillo_header",
+        "@eigen//:eigen",
         "@com_google_absl//absl/flags:flag",
         "@com_google_absl//absl/flags:parse",
         "@com_google_absl//absl/flags:usage",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -158,20 +158,21 @@ cc_library(
     urls = ["https://github.com/cjlin1/libsvm/archive/v324.zip"],
 )
 
-# Armadillo Headers
+# Eigen dependency
 http_archive(
-    name = "armadillo_headers",
+    name = "eigen",
     build_file_content = """
 cc_library(
-    name = "armadillo_header",
-    hdrs = glob(["include/armadillo", "include/armadillo_bits/*.hpp"]),
-    includes = ["include/"],
-    visibility = ["//visibility:public"],
+    name = 'eigen',
+    srcs = [],
+    includes = ['Eigen'],
+    hdrs = glob(['Eigen/**']),
+    visibility = ['//visibility:public'],
 )
 """,
-    sha256 = "53d7ad6124d06fdede8d839c091c649c794dae204666f1be0d30d7931737d635",
-    strip_prefix = "armadillo-9.900.1",
-    urls = ["http://sourceforge.net/projects/arma/files/armadillo-9.900.1.tar.xz"],
+    sha256 = "0fa5cafe78f66d2b501b43016858070d52ba47bd9b1016b0165a7b8e04675677",
+    strip_prefix = "eigen-3.3.9",
+    urls = ["https://gitlab.com/libeigen/eigen/-/archive/3.3.9/eigen-3.3.9.tar.bz2",],
 )
 
 # PFFFT

--- a/src/include/amatrix.h
+++ b/src/include/amatrix.h
@@ -17,13 +17,12 @@
 #ifndef VISQOL_INCLUDE_AMATRIX_H
 #define VISQOL_INCLUDE_AMATRIX_H
 
-#include <armadillo>
+#include "Eigen/Dense"
 #include <memory>
 #include <valarray>
 #include <vector>
 
 #include "absl/types/span.h"
-#define ARMA_64BIT_WORD
 
 #if defined(_MSC_VER) && _MSC_VER >= 1400
 #pragma warning(push)
@@ -32,6 +31,10 @@
 
 namespace Visqol {
 enum class kDimension { COLUMN = 0, ROW = 1 };
+
+// Define an alias for the Eigen matrix
+template<class T>
+using BackendMatrix = Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>;
 
 template <typename T>
 class AMatrix;
@@ -43,7 +46,7 @@ template <typename T>
 class AMatrix {
  public:
   AMatrix<T>() {}
-  AMatrix<T>(const arma::Mat<T>& mat);
+  AMatrix<T>(const BackendMatrix<T>& mat);
   AMatrix<T>(const AMatrix<T>& other);
   AMatrix<T>(const std::vector<T>& col);
   AMatrix<T>(const absl::Span<T>& col);
@@ -52,7 +55,7 @@ class AMatrix {
   AMatrix<T>(size_t rows, size_t cols);
   AMatrix<T>(size_t rows, size_t cols, std::vector<T>&& data);
   AMatrix<T>(size_t rows, size_t cols, const std::vector<T>& data);
-  AMatrix<T>(arma::Mat<T>&& matrix);  // could this be private?
+  AMatrix<T>(BackendMatrix<T>&& matrix);  // could this be private?
   T& operator()(size_t row, size_t column);
   T operator()(size_t row, size_t column) const;
   T& operator()(size_t elementIndex);
@@ -104,11 +107,11 @@ class AMatrix {
   std::valarray<T> ToValArray() const;
 
   // hack to access private member
-  const arma::Mat<T>& GetArmaMat() const;
+  const BackendMatrix<T>& GetBackendMat() const;
 
  public:
-  typedef typename arma::Mat<T>::iterator iterator;
-  typedef typename arma::Mat<T>::const_iterator const_iterator;
+  using iterator = T*;
+  using const_iterator = const T*;
   iterator begin();
   iterator end();
   const_iterator cbegin() const;
@@ -118,7 +121,7 @@ class AMatrix {
   T* mutData() const;  // bit of a hack
 
  private:
-  arma::Mat<T> matrix_;
+  BackendMatrix<T> matrix_;
 };
 }  // namespace Visqol
 


### PR DESCRIPTION
Hi everyone, I am opening this PR as the first part of some gammatone filterbank optimizations, proposed with #115. 

Here I am only replacing Armadillo with Eigen as the linear algebra backend. This change by itself is not providing any runtime improvements but it allows for a faster implementation of the gammatone filterbank if we use the Eigen matrix operations directly. I added more info on the proposed optimization in #115.

The main purpose of this PR is to split the first part of #115, to facilitate the review process.