### PR TITLE
Update Armadillo version to 14.2.3, as 9.900.1 is marked as retired in sourceforge

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -169,9 +169,8 @@ cc_library(
     visibility = ["//visibility:public"],
 )
 """,
-    sha256 = "53d7ad6124d06fdede8d839c091c649c794dae204666f1be0d30d7931737d635",
-    strip_prefix = "armadillo-9.900.1",
-    urls = ["http://sourceforge.net/projects/arma/files/armadillo-9.900.1.tar.xz"],
+    strip_prefix = "armadillo-14.2.3",
+    urls = ["https://sourceforge.net/projects/arma/files/armadillo-14.2.3.tar.xz"],
 )
 
 # PFFFT

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -169,7 +169,7 @@ cc_library(
     visibility = ["//visibility:public"],
 )
 """,
-    sha256 = "fc70c3089a8d2bb7f2510588597d4b35b4323f6d4be5db5c17c6dba20ab4a9cc"
+    sha256 = "fc70c3089a8d2bb7f2510588597d4b35b4323f6d4be5db5c17c6dba20ab4a9cc",
     strip_prefix = "armadillo-14.2.3",
     urls = ["http://sourceforge.net/projects/arma/files/armadillo-14.2.3.tar.xz"],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -169,8 +169,9 @@ cc_library(
     visibility = ["//visibility:public"],
 )
 """,
+    sha256 = "fc70c3089a8d2bb7f2510588597d4b35b4323f6d4be5db5c17c6dba20ab4a9cc"
     strip_prefix = "armadillo-14.2.3",
-    urls = ["https://sourceforge.net/projects/arma/files/armadillo-14.2.3.tar.xz"],
+    urls = ["http://sourceforge.net/projects/arma/files/armadillo-14.2.3.tar.xz"],
 )
 
 # PFFFT


### PR DESCRIPTION
I am not sure whether everything is compatible / no-op or not with this version, but I managed to build it locally and run visqol.

Looks like old Armadillo versions are kept getting retired, so another solution can be to update the url to:

- https://sourceforge.net/projects/arma/files/retired/armadillo-9.900.1.tar.xz.RETIRED