### PR TITLE
Changed armadillo download server

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -171,7 +171,7 @@ cc_library(
 """,
     sha256 = "53d7ad6124d06fdede8d839c091c649c794dae204666f1be0d30d7931737d635",
     strip_prefix = "armadillo-9.900.1",
-    urls = ["http://sourceforge.net/projects/arma/files/armadillo-9.900.1.tar.xz"],
+    urls = ["https://distfiles.macports.org/armadillo/armadillo-9.900.1.tar.xz"],
 )
 
 # PFFFT


### PR DESCRIPTION
In the previous server the needed version had already been deleted. This pr fixes build.