### PR TITLE
github_actions: Update upload-artifact to v4

### DIFF
--- a/.github/actions/visqol_builder/action.yml
+++ b/.github/actions/visqol_builder/action.yml
@@ -43,7 +43,7 @@ runs:
         fi
         cp model/lattice_tcditugenmeetpackhref_ls2_nl60_lr12_bs2048_learn.005_ep2400_train1_7_raw.tflite action-product/
         cp model/libsvm_nu_svr_model.txt  action-product/
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: visqol-${{ inputs.platform }}-${{ inputs.architecture }}
         path: action-product        


### PR DESCRIPTION
    Fixes the initial error in the github workflow.
    Armadillo still broken, but other PRs fix that.